### PR TITLE
fix(bookMeal): change API http method to Post

### DIFF
--- a/library/src/commonMain/kotlin/ink/literate/turbawself/api/book-meal.kt
+++ b/library/src/commonMain/kotlin/ink/literate/turbawself/api/book-meal.kt
@@ -25,7 +25,7 @@ suspend fun bookMeal(
         putJsonObject("web") { put("id", bookId) }
         put("hasHoteResaSoirActive", bookEvening)
       })
-  request.setHttpMethod(HttpMethod.Put)
+  request.setHttpMethod(HttpMethod.Post)
 
   val content = request.send(auth.client)
   val bookingData = content.jsonObject


### PR DESCRIPTION
Due to the recent update of Turboself, the 'reservations-jours' API endpoint is no longer available for the PUT http method but for the POST method instead. Thus, we are updating the method as well in the library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)